### PR TITLE
Feature/wb 86 - getOfferByTag

### DIFF
--- a/controllers/offerController.js
+++ b/controllers/offerController.js
@@ -189,8 +189,6 @@ const getOfferWithTags = async (req, res) => {
   tags.forEach(async (tagOffer) => {
     offers.add(tagOffer.offer);
   });
-
-  console.log(tags.length);
   res.status(200).json({
     status: 'success',
     results: offers.size,
@@ -200,10 +198,6 @@ const getOfferWithTags = async (req, res) => {
   });
 };
 
-exports.getOfferByTag  = catchAsync(async(req, res, next)=>{
-  if(req.query.tags){   
-    return getOfferWithTags(req,res);
-  }else{
-    return this.getAllOffers(req,res,next);
-  }
+exports.GetOffersHandler  = catchAsync(async(req, res, next)=>{
+  req.query.tags? getOfferWithTags(req,res) : this.getAllOffers(req,res,next);
 });

--- a/routes/offerRoutes.js
+++ b/routes/offerRoutes.js
@@ -7,7 +7,7 @@ const {
   protectOffer,
   deleteOffer,
   getMyOffers,
-  getOfferByTag,
+  GetOffersHandler,
 } = require('../controllers/offerController');
 const {
   restricTo,
@@ -18,7 +18,7 @@ const {
 const interactionRouter = require('./../routes/interactionRoutes');
 const router = express.Router();
 
-router.get('/', getOfferByTag);
+router.get('/', GetOffersHandler);
 router.get('/me',protect,verifyEmailValidation,restricTo('offerer'), getMyOffers);
 router.use('/interactions', interactionRouter);
 


### PR DESCRIPTION
**Changes:**
- Added `getOfferWithTags` endpoint on `GET {{HOST}}/api/v1/offers/?tags[]`
![image](https://user-images.githubusercontent.com/22641237/94375386-49290a00-00e1-11eb-84b9-1925fd45a229.png)
- Added `GetOffersHandler`

**Instructions:**
`GetOffersHandler` will redirect you to `getOfferWithTags` or `getAllOffers` depending of your request. If you do a `GET` to  `{{HOST}}/api/v1/offers/` will retrieve you every `offers `saved. If you want to get all `offers `from certain `tag`, you must do a `GET` to `{{HOST}}/api/v1/offers/` adding the array of tags you wanna search for on the query. for example `GET {{HOST}}/api/v1/offers/?tags[]=tag1&tags[]=tag2&.....&tags[]=tagN`
![image](https://user-images.githubusercontent.com/22641237/94375412-69f15f80-00e1-11eb-86de-be11e8a806a5.png)
The response will be an array of `offers` (objects) on `data.offers `
![image](https://user-images.githubusercontent.com/22641237/94375446-a7ee8380-00e1-11eb-864d-1a728c6488b3.png)
