### PR TITLE
Feature/wb 99 - Reimplementation of Organization’s RNC validation using the DGII database

### DIFF
--- a/models/organizationModel.js
+++ b/models/organizationModel.js
@@ -87,12 +87,12 @@ organizationSchema.pre('save', function (next) {
 });
 
 organizationSchema.methods.verifyRNCWithDGII = function () {
-  // console.log('Verifying RNC: ', this.RNC);
-  // isOrgRegisteredInDGII(this.RNC).then((isVerified) => {
-  //   console.log(`Verification result of RNC ${this.RNC}: `, isVerified);
-  //   this.isVerified = isVerified;
-  //   this.save();
-  // });
+  console.log('Verifying RNC: ', this.RNC);
+  isOrgRegisteredInDGII(this.RNC).then((isVerified) => {
+    console.log(`Verification result of RNC ${this.RNC}: `, isVerified);
+    this.isVerified = isVerified;
+    this.save();
+  });
 };
 
 const Organization = mongoose.model('Organization', organizationSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,14 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -113,9 +121,9 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
     "bl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
-      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -627,6 +635,11 @@
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "forwarded": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Yordi Ogando",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.20.0",
     "bcryptjs": "^2.4.3",
     "cloudinary": "^1.23.0",
     "cookie-parser": "^1.4.5",

--- a/utils/dgiiCrawler.js
+++ b/utils/dgiiCrawler.js
@@ -1,60 +1,13 @@
-// const puppeteer = require('puppeteer');
-const puppeteer = {};
-
-exports.getContributorDGIIData = async (rnc) => {
-  try {
-    const selector = '#cphMain_txtRNCCedula';
-    const browser = await puppeteer.launch();
-    const page = await browser.newPage();
-
-    // console.log('Going to page...');
-    await page.goto(
-      'https://dgii.gov.do/app/WebApps/ConsultasWeb2/ConsultasWeb/consultas/rnc.aspx'
-    );
-    await page.waitForSelector(selector);
-
-    // console.log('Clicking element...');
-    await page.click(selector);
-    await page.keyboard.type(rnc);
-
-    // console.log('Pressing enter...');
-    await page.keyboard.press('Enter');
-
-    await page.waitForTimeout(500);
-
-    const data = await page.evaluate(() => {
-      let data = {};
-      const firstCol = document.querySelectorAll('td[style="font-weight:bold;"]');
-      const secondCol = document.querySelectorAll('td:not([style="font-weight:bold;"])');
-
-      for (var i = 0; i < firstCol.length; i++) {
-        data[firstCol[i].innerText] = secondCol[i].innerText;
-      }
-
-      return data;
-    });
-
-    await page.close();
-    await browser.close();
-
-    return data;
-  } catch (error) {
-    console.log(error);
-    await browser.close();
-    return {};
-  }
-};
+const axios = require('axios');
 
 exports.isOrgRegisteredInDGII = async (rnc) => {
   try {
-    let verified = false;
-    const result = await this.getContributorDGIIData(rnc);
-
-    if (JSON.stringify(result) != JSON.stringify({})) verified = true;
-
-    return verified;
-  } catch (error) {
-    console.log(error);
+    const response = await axios.get(`${process.env.DGII_CRAWLER_HOST}/api/v1/rnc/${rnc}`, {
+      rnc,
+    });
+    return true;
+  } catch (e) {
+    e.response.status != 404 ? console.log(e.response.data) : undefined;
     return false;
   }
 };


### PR DESCRIPTION
**Changes**
- Due to that AWS Elastic Beanstalk service presented problems while deploying the app with the puppeteer package on it, a reimplementation of the organization's RNC verification was done using the DGII Crawler as an external API.
- Added `axios` package.